### PR TITLE
we should email submitters when their submission was rejected or deleted

### DIFF
--- a/src/model/constants/EmailTemplate.ts
+++ b/src/model/constants/EmailTemplate.ts
@@ -1,0 +1,7 @@
+enum EMAIL_TEMPLATE {
+    REJECTED,
+    DELETED,
+    NEW_SUBMISSION
+}
+
+export default EMAIL_TEMPLATE;

--- a/src/services/SubmissionConfirmationService.ts
+++ b/src/services/SubmissionConfirmationService.ts
@@ -11,6 +11,7 @@ import {SubmissionConfirmationRepo} from "../db/repo/SubmissionConfirmationRepo"
 import {SubmissionRepo} from "../db/repo/SubmissionRepo";
 import {UUID} from "crypto";
 import {Logger} from "@tsed/common";
+import EMAIL_TEMPLATE from "../model/constants/EmailTemplate";
 
 @Service()
 export class SubmissionConfirmationService implements OnInit {
@@ -86,7 +87,7 @@ export class SubmissionConfirmationService implements OnInit {
         const confirmationUrl = `${baseUrl}/processSubmission?uid=${guid}`;
         const body = `Please click the link below to confirm your submission. This link will expire in 20 minutes.\n${confirmationUrl}`;
         const to = pendingEntry.submission.submitterEmail;
-        const messageInfo = await this.emailService.sendMail(body, to);
+        const messageInfo = await this.emailService.sendMail(to, EMAIL_TEMPLATE.NEW_SUBMISSION, body);
         this.logger.info(`${to} email sent with guild ${guid}`);
         return messageInfo;
     }


### PR DESCRIPTION
when deleting a submission from an active round, it should email the submitter saying it was rejected.

When changing the status of a submittion to rejected on an already ended round, it should email with a reason.

when deleting a submission from an already ended round, it should not email 